### PR TITLE
uncommenting WD require to fix the failure due to missing wd

### DIFF
--- a/tests/tutorial-copy-specs.js
+++ b/tests/tutorial-copy-specs.js
@@ -1,4 +1,4 @@
-// wd = require('wd');
+wd = require('wd');
 require('colors');
 var _ = require("lodash");
 var chai = require("chai");


### PR DESCRIPTION
there were failures fixed by uncommenting a line.  Perhaps someone can tell me if there was a reason to keep it commented out?
